### PR TITLE
allow to simply build using sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,19 @@
+def commonSettings = Seq(
+  organization := "leo",
+  version := "0.3",
+  scalaVersion := "2.11.6",
+  name := "leo",
+  sourcesInBase := false,
+  scalaSource in Compile := baseDirectory.value / "src/main",
+  resourceDirectory in Compile := baseDirectory.value / "src/main/resources",
+  unmanagedJars in Compile := Seq.empty
+)
+
+lazy val leo = (project in file(".")).
+  settings(commonSettings: _*).
+  settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
+      "org.scala-lang.modules" %% "scala-xml" % "1.0.3")
+  )


### PR DESCRIPTION
We want a simply .jar file without the scala dependencies and use it within https://github.com/KWARC/MMT.

The added file `build.sbt` allows to call `sbt package`. This will create `target/scala-2.11/leo_2.11-0.3.jar`.

I could not convince maven to also create a .jar without the dependencies. I'm quite happy with SBT. In  https://github.com/KWARC/MMT/blob/svn-mirror/src/build.sbt we also create assembled jars for `mmt` and the jedit  `MMTPlugin`.

Keeping both files, `pom.xml` and `build.sbt`, (wrt versions) up-to-date might be extra work, though.
